### PR TITLE
add java.util.UUID default value

### DIFF
--- a/src/main/java/com/lilittlecat/plugin/common/Constants.java
+++ b/src/main/java/com/lilittlecat/plugin/common/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
             put("java.util.HashSet", "new HashSet<>()");
             put("java.util.Map", "new HashMap<>()");
             put("java.util.HashMap", "new HashMap<>()");
+            put("java.util.UUID", "UUID.randomUUID()");
         }
     };
 


### PR DESCRIPTION
Hello!
I really like your plugin but it always annoys me when it generates "new UUID()" (which is incorrect) instead of "UUID.randomUUID()", so I decided that it would be a good idea to add this little feature to your plugin!
I hope you'll accept it :)

P.S. Also, I am a participant of Hacktoberfest 2022, so it would be great if you'd label this PR as "hacktoberfest-accepted”

Have a good day!